### PR TITLE
Tuning lto and opt-level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ crate-type = ["cdylib", "rlib"]
 
 # optimize for smaller WASM binary size
 [profile.release]
-lto = true
-opt-level = 3
+lto = "thin"
+opt-level = "s"
 codegen-units = 1
 incremental = false
 debug = false


### PR DESCRIPTION
- lto: true -> thin
- opt-level: 3 -> s targeting to smaller wasm size without much performance lose.