### PR TITLE
Set opt-level=0 for fast dev iteration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,4 @@ incremental = false
 debug = false
 
 [profile.dev]
-opt-level = 1
-
-[profile.dev.package."*"]
-opt-level = 3
+opt-level = 0


### PR DESCRIPTION
This might not ideal when project get bigger, for the moment, it is totally fine since we just render some balls in the screen.

solve #20