### PR TITLE
add axes and second camera for it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub(crate) mod parse;
 pub(crate) mod structure;
 
 use crate::io::load_crystal;
-use crate::ui::{camera_controls, setup_camera, setup_scene};
+use crate::ui::{camera_controls, setup_cameras, setup_scene, spawn_axis};
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
@@ -29,7 +29,9 @@ pub fn run_app() {
             filter: "wgpu=error,bevy_render=info,bevy_ecs=trace".to_string(),
             custom_layer: |_| None,
         }))
-        .add_systems(Startup, (load_crystal, setup_scene, setup_camera).chain())
+        .add_systems(Startup, load_crystal)
+        .add_systems(Startup, setup_scene.after(load_crystal))
+        .add_systems(Startup, (setup_cameras, spawn_axis).after(setup_scene))
         .add_systems(Update, camera_controls)
         .run();
 }


### PR DESCRIPTION
fixes #5

I use two camera entities to do it. The main camera is look at the structure. The gizmo camera is look at the coordinates and rendering to the left-bottom corner. This technology is similar to the mini-map in the rpg game.

The axes idea is same to Blender and UR engine to have a axes marker showing the orientation.