### PR TITLE
adding wireframe for cell and extend structure to support it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,6 +1605,7 @@ dependencies = [
 [[package]]
 name = "ccmat-core"
 version = "0.1.0"
+source = "git+https://github.com/unkcpz/ccmat.git?branch=master#e4a008aef74b29bd045503079ac7e680db3cd414"
 dependencies = [
  "ccmat-macros",
 ]
@@ -1612,6 +1613,7 @@ dependencies = [
 [[package]]
 name = "ccmat-macros"
 version = "0.1.0"
+source = "git+https://github.com/unkcpz/ccmat.git?branch=master#e4a008aef74b29bd045503079ac7e680db3cd414"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3660,9 +3662,6 @@ name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
-version = "1.0.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
@@ -3687,9 +3686,6 @@ name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
-version = "1.0.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -4041,9 +4037,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
 ]
@@ -4203,9 +4199,6 @@ name = "syn"
 version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
-version = "2.0.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4327,14 +4320,14 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.9.8"
+version = "0.9.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
 dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 0.7.3",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow",
@@ -4351,9 +4344,6 @@ name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
 dependencies = [
  "serde_core",
 ]
@@ -4377,7 +4367,6 @@ checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
  "toml_datetime 0.7.5+spec-1.1.0",
- "toml_datetime 0.7.3",
  "toml_parser",
  "winnow",
 ]
@@ -4387,18 +4376,15 @@ name = "toml_parser"
 version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.4"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tracing"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1603,6 +1603,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ccmat-core"
+version = "0.1.0"
+dependencies = [
+ "ccmat-macros",
+]
+
+[[package]]
+name = "ccmat-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "trybuild",
+]
+
+[[package]]
 name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3643,6 +3660,9 @@ name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
@@ -3667,6 +3687,9 @@ name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+version = "1.0.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -4017,6 +4040,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4171,6 +4203,9 @@ name = "syn"
 version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+version = "2.0.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4210,6 +4245,12 @@ dependencies = [
  "serde",
  "slotmap",
 ]
+
+[[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
 
 [[package]]
 name = "termcolor"
@@ -4285,6 +4326,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "toml"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.3",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4295,6 +4351,9 @@ name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
 dependencies = [
  "serde_core",
 ]
@@ -4318,6 +4377,7 @@ checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
  "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime 0.7.3",
  "toml_parser",
  "winnow",
 ]
@@ -4327,9 +4387,18 @@ name = "toml_parser"
 version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
 
 [[package]]
 name = "tracing"
@@ -4416,6 +4485,21 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e17e807bff86d2a06b52bca4276746584a78375055b6e45843925ce2802b335"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
 ]
 
 [[package]]
@@ -4598,6 +4682,7 @@ dependencies = [
  "anyhow",
  "async-tungstenite",
  "bevy",
+ "ccmat-core",
  "crossbeam-channel",
  "futures-util",
  "js-sys",

--- a/vizmat-core/Cargo.toml
+++ b/vizmat-core/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 crossbeam-channel = "0.5"
+ccmat-core = { git = "https://github.com/unkcpz/ccmat.git", branch = "master" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-tungstenite = { version = "0.32.0", features = ["async-std", "async-std-runtime"] }

--- a/vizmat-core/src/client.rs
+++ b/vizmat-core/src/client.rs
@@ -1,7 +1,7 @@
 // WebSocket client module for connecting to structure update server
 // Supports both native (async-tungstenite) and WASM (web-sys) targets
 
-use crate::structure::{Atom, UpdateStructure};
+use crate::structure::{Site, UpdateStructure};
 use bevy::prelude::*;
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use serde::{Deserialize, Serialize};
@@ -19,9 +19,9 @@ struct StructureMessage {
     atoms: Vec<AtomData>,
 }
 
-impl From<AtomData> for Atom {
+impl From<AtomData> for Site {
     fn from(data: AtomData) -> Self {
-        Atom {
+        Site {
             element: data.element,
             x: data.x,
             y: data.y,
@@ -59,12 +59,9 @@ pub fn poll_websocket_stream(
     stream: Res<WebSocketStream>,
     mut events: EventWriter<UpdateStructure>,
 ) {
-    while let Ok(update) = stream.receiver.try_recv() {
-        info!(
-            "Received structure update with {} atoms",
-            update.atoms.len()
-        );
-        events.write(update);
+    while let Ok(s) = stream.receiver.try_recv() {
+        info!("Received structure update with {} atoms", s.sites.len());
+        events.write(s);
     }
 }
 
@@ -92,13 +89,13 @@ fn setup_native_websocket(tx: Sender<UpdateStructure>) {
                             if let Ok(structure_msg) =
                                 serde_json::from_str::<StructureMessage>(&text)
                             {
-                                let atoms = structure_msg
+                                let sites = structure_msg
                                     .atoms
                                     .into_iter()
                                     .map(std::convert::Into::into)
                                     .collect();
 
-                                if tx.send(UpdateStructure { atoms }).is_err() {
+                                if tx.send(UpdateStructure { sites }).is_err() {
                                     println!("Bevy channel closed");
                                     break;
                                 }

--- a/vizmat-core/src/io.rs
+++ b/vizmat-core/src/io.rs
@@ -3,13 +3,18 @@ use bevy::prelude::*;
 use std::path::PathBuf;
 
 use crate::parse::parse_xyz_content;
-use crate::structure::{Atom, Crystal};
+use crate::structure::{Atom, Crystal, Lattice};
 
 // System to load default crystal data
 pub(crate) fn load_default_crystal(mut commands: Commands) {
     println!("Loading default water molecule structure");
 
     let crystal = Crystal {
+        lattice: Lattice::new(
+            Vec3::new(5., 0., 0.),
+            Vec3::new(0., 5., 0.),
+            Vec3::new(0., 0., 5.),
+        ),
         atoms: vec![
             Atom {
                 element: "O".to_string(),

--- a/vizmat-core/src/io.rs
+++ b/vizmat-core/src/io.rs
@@ -1,45 +1,35 @@
 // io.rs
 use bevy::prelude::*;
+use ccmat_core::{atomic_number, lattice_angstrom, sites_frac_coord, CrystalBuilder};
 use std::path::PathBuf;
 
 use crate::parse::parse_xyz_content;
-use crate::structure::{Atom, Crystal, Lattice};
+use crate::structure::Crystal;
 
 // System to load default crystal data
+#[allow(clippy::unreadable_literal)]
 pub(crate) fn load_default_crystal(mut commands: Commands) {
     println!("Loading default water molecule structure");
 
-    let crystal = Crystal {
-        lattice: Lattice::new(
-            Vec3::new(5., 0., 0.),
-            Vec3::new(0., 5., 0.),
-            Vec3::new(0., 0., 5.),
-        ),
-        atoms: vec![
-            Atom {
-                element: "O".to_string(),
-                x: 0.0,
-                y: 0.0,
-                z: 0.0,
-            },
-            Atom {
-                element: "H".to_string(),
-                x: 0.757,
-                y: 0.587,
-                z: 0.0,
-            },
-            Atom {
-                element: "H".to_string(),
-                x: -0.757,
-                y: 0.587,
-                z: 0.0,
-            },
-        ],
-    };
+    let lattice = lattice_angstrom![
+        a = (-1.61742302102767, 1.61742302102767, 1.61742302102767),
+        b = (1.61742302102767, -1.61742302102767, 1.61742302102767),
+        c = (1.61742302102767, 1.61742302102767, -1.61742302102767),
+    ];
+
+    let sites = sites_frac_coord![
+        (0.0, 0.0, 0.0), atomic_number!(Si);
+    ];
+    let inner = CrystalBuilder::new()
+        .with_lattice(&lattice)
+        .with_sites(sites)
+        .build_uncheck();
+    let crystal = Crystal { inner };
 
     commands.insert_resource(crystal);
 }
 
+// XXX: why need option??
 // Resource to handle file drag and drop
 #[derive(Resource, Default)]
 pub(crate) struct FileDragDrop {
@@ -116,13 +106,21 @@ pub(crate) fn update_crystal_from_file(
     if let Some(crystal) = &file_drag_drop.loaded_crystal {
         // Only update if this is a new crystal
         if let Some(current) = current_crystal {
-            if current.atoms.len() != crystal.atoms.len() {
+            if current.inner.species().len() != crystal.inner.species().len() {
+                // XXX: I really should not clone here!!
                 commands.insert_resource(crystal.clone());
-                println!("Crystal updated with {} atoms", crystal.atoms.len());
+                println!(
+                    "Crystal updated with {} atoms",
+                    crystal.inner.species().len()
+                );
             }
         } else {
+            // XXX: I really should not clone here!!
             commands.insert_resource(crystal.clone());
-            println!("Crystal loaded with {} atoms", crystal.atoms.len());
+            println!(
+                "Crystal loaded with {} atoms",
+                crystal.inner.species().len()
+            );
         }
     }
 }

--- a/vizmat-core/src/parse.rs
+++ b/vizmat-core/src/parse.rs
@@ -1,5 +1,6 @@
-use crate::structure::{Atom, Crystal};
+use crate::structure::{Atom, Crystal, Lattice};
 use anyhow::{Context, Result};
+use bevy::math::Vec3;
 
 // Function to parse XYZ file format from string content
 pub(crate) fn parse_xyz_content(contents: &str) -> Result<Crystal> {
@@ -43,5 +44,12 @@ pub(crate) fn parse_xyz_content(contents: &str) -> Result<Crystal> {
         atoms.push(atom);
     }
 
-    Ok(Crystal { atoms })
+    // FIXME: use extxyz
+    let lattice = Lattice::new(
+        Vec3::new(5., 0., 0.),
+        Vec3::new(0., 5., 0.),
+        Vec3::new(0., 0., 5.),
+    );
+
+    Ok(Crystal { lattice, atoms })
 }

--- a/vizmat-core/src/parse.rs
+++ b/vizmat-core/src/parse.rs
@@ -1,6 +1,8 @@
-use crate::structure::{Atom, Crystal, Lattice};
+use crate::structure::Crystal;
 use anyhow::{Context, Result};
-use bevy::math::Vec3;
+use ccmat_core::{
+    atomic_number_from_symbol, lattice_angstrom, math::Vector3, CrystalBuilder, Site,
+};
 
 // Function to parse XYZ file format from string content
 pub(crate) fn parse_xyz_content(contents: &str) -> Result<Crystal> {
@@ -22,7 +24,7 @@ pub(crate) fn parse_xyz_content(contents: &str) -> Result<Crystal> {
     // Parse extended XYZ properties if present (basic implementation)
     // For now, we'll focus on the basic XYZ format
 
-    let mut atoms = Vec::new();
+    let mut sites = Vec::new();
 
     for (i, line) in lines.iter().skip(2).enumerate() {
         if i >= num_atoms {
@@ -34,22 +36,24 @@ pub(crate) fn parse_xyz_content(contents: &str) -> Result<Crystal> {
             continue; // Skip malformed lines
         }
 
-        let atom = Atom {
-            element: parts[0].to_string(),
-            x: parts[1].parse().context("Failed to parse x coordinate")?,
-            y: parts[2].parse().context("Failed to parse y coordinate")?,
-            z: parts[3].parse().context("Failed to parse z coordinate")?,
-        };
+        let (x, y, z): (f64, f64, f64) = (
+            parts[1].parse().context("Failed to parse x coordinate")?,
+            parts[2].parse().context("Failed to parse y coordinate")?,
+            parts[3].parse().context("Failed to parse z coordinate")?,
+        );
+        let position = Vector3([x.into(), y.into(), z.into()]);
+        let sym = parts[0].to_string();
+        let site = Site::new(position, atomic_number_from_symbol(&sym)?);
 
-        atoms.push(atom);
+        sites.push(site);
     }
 
     // FIXME: use extxyz
-    let lattice = Lattice::new(
-        Vec3::new(5., 0., 0.),
-        Vec3::new(0., 5., 0.),
-        Vec3::new(0., 0., 5.),
-    );
+    let lattice = lattice_angstrom![a = (5., 0., 0.), b = (0., 5., 0.), c = (0., 0., 5.),];
+    let crystal = CrystalBuilder::new()
+        .with_lattice(&lattice)
+        .with_sites(sites)
+        .build()?;
 
-    Ok(Crystal { lattice, atoms })
+    Ok(Crystal { inner: crystal })
 }

--- a/vizmat-core/src/structure.rs
+++ b/vizmat-core/src/structure.rs
@@ -1,10 +1,11 @@
 use bevy::prelude::*;
+use ccmat_core::{atomic_number_from_symbol, math::Vector3, CrystalBuilder, FracCoord};
 
 // Structure to represent an atom from XYZ file
 // `#` is a macro. no inheritance. close to python decorator. injecting on top of something.
 // traits are like interfaces.
 #[derive(Debug, Clone)]
-pub struct Atom {
+pub struct Site {
     pub element: String,
     pub x: f32,
     pub y: f32,
@@ -38,9 +39,71 @@ impl Lattice {
 
 // Structure to hold our crystal data
 #[derive(Resource, Clone)]
-pub struct Crystal {
-    pub lattice: Lattice,
-    pub atoms: Vec<Atom>,
+pub(crate) struct Crystal {
+    pub(crate) inner: ccmat_core::Crystal,
+}
+
+impl Crystal {
+    // I can cast because IMO, the accuracy in vitualizer rendering is not essential.
+    // XXX: but such re-allocation is not ideal.
+    #[allow(clippy::cast_possible_truncation)]
+    pub(crate) fn lattice(&self) -> Lattice {
+        let latt = self.inner.lattice();
+        let [ax, ay, az] = latt.a().map(|i| f64::from(i) as f32);
+        let [bx, by, bz] = latt.b().map(|i| f64::from(i) as f32);
+        let [cx, cy, cz] = latt.c().map(|i| f64::from(i) as f32);
+        Lattice::new(
+            Vec3::new(ax, ay, az),
+            Vec3::new(bx, by, bz),
+            Vec3::new(cx, cy, cz),
+        )
+    }
+
+    pub(crate) fn positions(&self) -> Vec<[f32; 3]> {
+        self.inner
+            .cartesian_positions()
+            .iter()
+            .map(|p| p.map(|s| f64::from(s) as f32))
+            .collect()
+    }
+
+    pub(crate) fn elements(&self) -> Vec<String> {
+        self.inner.species().iter().map(|p| p.symbol()).collect()
+    }
+
+    pub(crate) fn sites(&self) -> Vec<Site> {
+        self.positions()
+            .iter()
+            .zip(self.elements())
+            .map(|(p, e)| Site {
+                element: e,
+                x: p[0],
+                y: p[1],
+                z: p[2],
+            })
+            .collect()
+    }
+
+    pub(crate) fn set_sites(&mut self, sites: &[Site]) {
+        let lattice = self.inner.lattice();
+        let sites = sites
+            .iter()
+            .map(|s| {
+                ccmat_core::Site::new(
+                    Vector3([
+                        FracCoord::from(f64::from(s.x)),
+                        FracCoord::from(f64::from(s.y)),
+                        FracCoord::from(f64::from(s.z)),
+                    ]),
+                    atomic_number_from_symbol(&s.element).expect("not a valid symbol"),
+                )
+            })
+            .collect::<Vec<_>>();
+        self.inner = CrystalBuilder::new()
+            .with_lattice(&lattice)
+            .with_sites(sites)
+            .build_uncheck();
+    }
 }
 
 // XXX: entity is the id point to the thing consist of components
@@ -52,7 +115,7 @@ pub struct AtomEntity;
 // Event to update the structure with new atom positions
 #[derive(Event, Clone)]
 pub struct UpdateStructure {
-    pub atoms: Vec<Atom>,
+    pub sites: Vec<Site>,
 }
 
 // System to handle incoming structure updates
@@ -62,7 +125,7 @@ pub fn update_crystal_system(
 ) {
     if let Some(mut crystal) = crystal {
         for event in events.read() {
-            crystal.atoms.clone_from(&event.atoms);
+            crystal.set_sites(&event.sites);
         }
     }
 }

--- a/vizmat-core/src/structure.rs
+++ b/vizmat-core/src/structure.rs
@@ -11,9 +11,35 @@ pub struct Atom {
     pub z: f32,
 }
 
+#[derive(Clone)]
+pub(crate) struct Lattice {
+    a: Vec3,
+    b: Vec3,
+    c: Vec3,
+}
+
+impl Lattice {
+    pub fn new(a: Vec3, b: Vec3, c: Vec3) -> Self {
+        Lattice { a, b, c }
+    }
+
+    pub fn a(&self) -> Vec3 {
+        self.a
+    }
+
+    pub fn b(&self) -> Vec3 {
+        self.b
+    }
+
+    pub fn c(&self) -> Vec3 {
+        self.c
+    }
+}
+
 // Structure to hold our crystal data
 #[derive(Resource, Clone)]
 pub struct Crystal {
+    pub lattice: Lattice,
     pub atoms: Vec<Atom>,
 }
 

--- a/vizmat-core/src/ui.rs
+++ b/vizmat-core/src/ui.rs
@@ -2,9 +2,11 @@
 
 use std::collections::HashMap;
 
+use bevy::asset::RenderAssetUsages;
 use bevy::input::mouse::{MouseMotion, MouseWheel};
 use bevy::prelude::*;
 use bevy::render::camera::Viewport;
+use bevy::render::mesh::{Indices, PrimitiveTopology};
 use bevy::render::view::RenderLayers;
 
 use crate::constants::{get_element_color, get_element_size};
@@ -179,8 +181,9 @@ pub(crate) fn update_scene(
                 commands.entity(entity).despawn();
             }
 
-            // Spawn new atoms
-            spawn_atoms(&mut commands, &mut meshes, &mut materials, &crystal);
+            // Spawn new crystal
+            // FIXME: this is not ideal, because there is always new structure allocated
+            spawn_crystal(&mut commands, &mut meshes, &mut materials, &crystal);
 
             println!("Scene updated with new crystal structure");
         }
@@ -188,12 +191,24 @@ pub(crate) fn update_scene(
 }
 
 // Helper function to spawn atoms
-fn spawn_atoms(
+fn spawn_crystal(
     commands: &mut Commands,
     meshes: &mut ResMut<Assets<Mesh>>,
     materials: &mut ResMut<Assets<StandardMaterial>>,
     crystal: &Crystal,
 ) {
+    // create cell axis
+    let latt = &crystal.lattice; // & to avoid clone
+    let (a, b, c) = (latt.a(), latt.b(), latt.c());
+    let mesh = create_wireframe_mesh(&a, &b, &c);
+    let mesh = meshes.add(mesh);
+    let material = materials.add(StandardMaterial {
+        base_color: Color::WHITE,
+        unlit: true,
+        ..default()
+    });
+    commands.spawn((Mesh3d(mesh), MeshMaterial3d(material), Transform::default()));
+
     // Create a sphere mesh for atoms
     let sphere_mesh = meshes.add(Sphere::new(1.0));
 
@@ -415,7 +430,7 @@ pub(crate) fn spawn_axis(
 }
 
 // System to refresh atoms when Crystal resource changes
-pub fn refresh_atoms_system(
+pub(crate) fn refresh_atoms_system(
     mut commands: Commands,
     crystal: Option<Res<Crystal>>,
     atom_entities: Query<Entity, With<AtomEntity>>,
@@ -548,7 +563,7 @@ pub(crate) fn camera_controls(
 }
 
 #[allow(clippy::type_complexity)]
-pub fn toggle_light_attachment(
+pub(crate) fn toggle_light_attachment(
     mut commands: Commands,
     light: Res<MainLightEntity>,
     camera: Res<MainCameraEntity>,
@@ -622,7 +637,7 @@ pub fn toggle_light_attachment(
 
 // Handle reset button interaction.
 #[allow(clippy::type_complexity)]
-pub fn reset_camera_button_interaction(
+pub(crate) fn reset_camera_button_interaction(
     mut interactions: Query<
         (&Interaction, &mut BackgroundColor),
         (Changed<Interaction>, With<ResetCameraButton>),
@@ -658,4 +673,33 @@ pub fn reset_camera_button_interaction(
             }
         }
     }
+}
+
+// create box frames as the cell
+fn create_wireframe_mesh(a: &Vec3, b: &Vec3, c: &Vec3) -> Mesh {
+    // look at the direction of c
+    let vertices = vec![
+        // bottom
+        [0., 0., 0.],
+        [a.x, a.y, a.z],
+        [a.x + b.x, a.y + b.y, a.z + b.z],
+        [b.x, b.y, b.z],
+        // // top,
+        [c.x, c.y, c.z],
+        [c.x + a.x, c.y + a.y, c.z + a.z],
+        [c.x + a.x + b.x, c.y + a.y + b.y, c.z + a.z + b.z],
+        [c.x + b.x, c.x + b.y, c.z + b.z],
+    ];
+
+    let indices = vec![
+        0, 1, 1, 2, 2, 3, 3, 0, // bottom
+        4, 5, 5, 6, 6, 7, 7, 4, // top
+        0, 4, 1, 5, 2, 6, 3, 7, // sides
+    ];
+
+    let mut mesh = Mesh::new(PrimitiveTopology::LineList, RenderAssetUsages::default());
+    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertices);
+
+    mesh.insert_indices(Indices::U32(indices));
+    mesh
 }

--- a/vizmat-core/src/ui.rs
+++ b/vizmat-core/src/ui.rs
@@ -198,7 +198,7 @@ fn spawn_crystal(
     crystal: &Crystal,
 ) {
     // create cell axis
-    let latt = &crystal.lattice; // & to avoid clone
+    let latt = &crystal.lattice(); // & to avoid clone
     let (a, b, c) = (latt.a(), latt.b(), latt.c());
     let mesh = create_wireframe_mesh(&a, &b, &c);
     let mesh = meshes.add(mesh);
@@ -216,13 +216,13 @@ fn spawn_crystal(
     let mut element_materials: HashMap<String, Handle<StandardMaterial>> = HashMap::new();
 
     // Spawn atoms as 3D spheres
-    for atom in &crystal.atoms {
+    for site in &crystal.sites() {
         // Get or create material for this element
         let material = element_materials
-            .entry(atom.element.clone())
+            .entry(site.element.clone())
             .or_insert_with(|| {
                 materials.add(StandardMaterial {
-                    base_color: get_element_color(&atom.element),
+                    base_color: get_element_color(&site.element),
                     metallic: 0.0,
                     ..default()
                 })
@@ -233,8 +233,8 @@ fn spawn_crystal(
         commands.spawn((
             Mesh3d(sphere_mesh.clone()),
             MeshMaterial3d(material),
-            Transform::from_xyz(atom.x, atom.y, atom.z)
-                .with_scale(Vec3::splat(get_element_size(&atom.element))),
+            Transform::from_xyz(site.x, site.y, site.z)
+                .with_scale(Vec3::splat(get_element_size(&site.element))),
             AtomEntity,
         ));
     }
@@ -454,13 +454,13 @@ pub(crate) fn refresh_atoms_system(
     let mut element_materials: HashMap<String, Handle<StandardMaterial>> = HashMap::new();
 
     if let Some(crystal) = crystal {
-        for atom in &crystal.atoms {
+        for (p, e) in crystal.positions().iter().zip(crystal.elements()) {
             // Get or create material for this element
             let material = element_materials
-                .entry(atom.element.clone())
+                .entry(e.clone())
                 .or_insert_with(|| {
                     materials.add(StandardMaterial {
-                        base_color: get_element_color(&atom.element),
+                        base_color: get_element_color(&e),
                         metallic: 0.0,
                         ..default()
                     })
@@ -471,8 +471,8 @@ pub(crate) fn refresh_atoms_system(
                 Mesh3d(sphere_mesh.clone()),
                 MeshMaterial3d(material),
                 Transform {
-                    translation: Vec3::new(atom.x, atom.y, atom.z),
-                    scale: Vec3::splat(get_element_size(&atom.element)),
+                    translation: Vec3::new(p[0], p[1], p[2]),
+                    scale: Vec3::splat(get_element_size(&e)),
                     ..default()
                 },
                 AtomEntity,


### PR DESCRIPTION
fixes #25 

- [x] wireframe with crystal as cell
- [x] use extxyz to parse
- [x] use ccmat-core to hold the structure
- [x] update_scene for every frame re-allocate the crystal if it changes, performance wise not ideal. Make it a dedicate issue to be improve, this will be a good selling point when comes to view the huge amount of MD time frames.  (https://github.com/rs4rse/vizmat/issues/33)
- [ ] enhance: too much copy when loading structure, should have a view on the inner crystal data structure in if used in immutable case. 
- [ ] by default use orthographic projection, can switch to perspective projection.